### PR TITLE
feat: validate req jwt with cognito public sign key

### DIFF
--- a/lambda/batchSubmit/lambda_function.py
+++ b/lambda/batchSubmit/lambda_function.py
@@ -8,7 +8,7 @@ from uuid import uuid4 as uuid
 from shared.apiutils import bad_request, bundle_response
 from shared.dynamodb import check_user_in_project, update_clinic_job
 from shared.utils import LoggingClient
-from shared.utils import require_permission, PermissionError
+from shared.utils import require_permission, InsufficientPermissionError
 from dynamodb import batch_check_duplicate_job_name
 
 
@@ -126,7 +126,7 @@ def lambda_handler(event, _):
 
     try:
         require_permission(event, "clinical_workflow_execution.create")
-    except PermissionError as e:
+    except InsufficientPermissionError as e:
         return bundle_response(
             403,
             {

--- a/lambda/getResultsURL/lambda_function.py
+++ b/lambda/getResultsURL/lambda_function.py
@@ -10,7 +10,7 @@ from shared.utils import (
     print_event,
     generate_presigned_get_url,
     require_permission, 
-    PermissionError
+    InsufficientPermissionError
 )
 from shared.indexutils import search_index_entry, get_index_page
 from dynamodb import check_user_in_project
@@ -136,7 +136,7 @@ def lambda_handler(event, _):
                     "filters": FILTERS,
                 },
             )
-    except PermissionError as e:
+    except InsufficientPermissionError as e:
         return bundle_response(
             403,
             {

--- a/lambda/initQuery/lambda_function.py
+++ b/lambda/initQuery/lambda_function.py
@@ -6,6 +6,12 @@ import traceback
 
 import boto3
 from botocore.client import ClientError
+import requests
+from cryptography.x509 import load_pem_x509_certificate
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import padding
+import base64
+from functools import lru_cache
 
 from shared.apiutils import bad_request, bundle_response
 from shared.utils import (
@@ -25,16 +31,82 @@ from dynamodb import does_clinic_job_exist_by_name
 from shared.utils import (
     require_permission,
     require_any_permission,
-    PermissionError,
+    InsufficientPermissionError,
 )
 
 # Environment variables
 CONCAT_STARTER_SNS_TOPIC_ARN = os.environ["CONCAT_STARTER_SNS_TOPIC_ARN"]
 SLICE_SIZE_MBP = int(os.environ["SLICE_SIZE_MBP"])
+ALLOWED_SNS_TOPIC_ARNS = os.environ.get("ALLOWED_SNS_TOPIC_ARNS", "").split(",")
 os.environ["PATH"] += f":{os.environ['LAMBDA_TASK_ROOT']}"
 
 REGIONS = chrom_matching.get_regions(SLICE_SIZE_MBP)
 REFERENCE_IDS = ["clinvar_version", "ensembl_version", "gnomad_constraints_version"]
+
+
+@lru_cache(maxsize=10)
+def get_sns_certificate(cert_url: str):
+    """Fetch and cache SNS signing certificate."""
+    # Validate cert URL is from AWS
+    if not cert_url.startswith("https://sns.") or ".amazonaws.com/" not in cert_url:
+        raise ValueError("Invalid certificate URL - not from AWS SNS")
+    
+    response = requests.get(cert_url, timeout=5)
+    response.raise_for_status()
+    return load_pem_x509_certificate(response.content)
+
+
+def verify_sns_signature(record: dict) -> bool:
+    """
+    Verify that an SNS message is genuinely from AWS SNS.
+    Returns True if valid, raises exception otherwise.
+    """
+    sns_message = record.get("Sns", {})
+    
+    # Build the string to sign based on message type
+    message_type = sns_message.get("Type", "Notification")
+    
+    if message_type == "Notification":
+        fields = ["Message", "MessageId", "Subject", "Timestamp", "TopicArn", "Type"]
+    else:
+        # SubscriptionConfirmation or UnsubscribeConfirmation
+        fields = ["Message", "MessageId", "SubscribeURL", "Timestamp", "Token", "TopicArn", "Type"]
+    
+    string_to_sign = ""
+    for field in fields:
+        value = sns_message.get(field)
+        if value is not None:
+            string_to_sign += f"{field}\n{value}\n"
+    
+    # Get certificate and verify signature
+    cert_url = sns_message.get("SigningCertUrl") or sns_message.get("SigningCertURL")
+    if not cert_url:
+        raise ValueError("Missing SigningCertUrl in SNS message")
+    
+    certificate = get_sns_certificate(cert_url)
+    signature = base64.b64decode(sns_message.get("Signature", ""))
+    
+    # Verify signature
+    public_key = certificate.public_key()
+    public_key.verify(
+        signature,
+        string_to_sign.encode("utf-8"),
+        padding.PKCS1v15(),
+        hashes.SHA1(),  # SNS uses SHA1 for signatures
+    )
+    
+    return True
+
+
+def validate_sns_source(record: dict):
+    """Validate that SNS message is from a trusted topic."""
+    topic_arn = record.get("Sns", {}).get("TopicArn", "")
+    
+    if ALLOWED_SNS_TOPIC_ARNS and ALLOWED_SNS_TOPIC_ARNS[0]:  # Check if configured
+        if topic_arn not in ALLOWED_SNS_TOPIC_ARNS:
+            raise ValueError(f"SNS message from unauthorized topic: {topic_arn}")
+    
+    return True
 
 
 def handle_init_failure(result, is_batch_job):
@@ -58,7 +130,27 @@ def handle_init_failure(result, is_batch_job):
 
 def parse_sns(event):
     try:
-        message = json.loads(event["Records"][0]["Sns"]["Message"])
+        record = event["Records"][0]
+        
+        # 🔐 Verify SNS signature to ensure message is from AWS
+        try:
+            verify_sns_signature(record)
+        except Exception as e:
+            return {
+                "Success": False,
+                "error": f"SNS signature verification failed: {str(e)}",
+            }
+        
+        # 🔐 Validate the message is from an allowed topic
+        try:
+            validate_sns_source(record)
+        except ValueError as e:
+            return {
+                "Success": False,
+                "error": str(e),
+            }
+        
+        message = json.loads(record["Sns"]["Message"])
     except (KeyError, ValueError) as e:
         return {
             "success": False,
@@ -169,7 +261,7 @@ def lambda_handler(event, _):
                     "clinical_workflow_execution.update",
                 ],
             )
-        except PermissionError as e:
+        except InsufficientPermissionError as e:
             return bundle_response(
                 403,
                 {

--- a/lambda/qcNotes/lambda_function.py
+++ b/lambda/qcNotes/lambda_function.py
@@ -3,7 +3,7 @@ import os
 import boto3
 import json
 from shared.apiutils import bad_request, bundle_response
-from shared.utils import require_permission, PermissionError
+from shared.utils import require_permission, InsufficientPermissionError
 
 
 s3_client = boto3.client("s3")
@@ -66,7 +66,7 @@ def lambda_handler(event, context):
                 notes = json.loads(event["body"] or "\"\"")
                 return update_notes(project_name, file_name, notes)
 
-    except PermissionError as e:
+    except InsufficientPermissionError as e:
         return bundle_response(
             403,
             {

--- a/shared_resources/python-modules/python/shared/utils/__init__.py
+++ b/shared_resources/python-modules/python/shared/utils/__init__.py
@@ -45,7 +45,7 @@ from .reference_utils import (
 )
 from .cognito_utils import get_cognito_user_by_id
 from .auth import (
-    PermissionError,
+    InsufficientPermissionError,
     require_permission,
     require_any_permission
 )

--- a/shared_resources/python-modules/python/shared/utils/auth.py
+++ b/shared_resources/python-modules/python/shared/utils/auth.py
@@ -1,23 +1,72 @@
 import json
 import base64
+import os
+import jwt
+import requests
+from functools import lru_cache
 
 
 class PermissionError(Exception):
     pass
 
 
-def base64url_decode(input_str: str) -> bytes:
-    padding = "=" * (-len(input_str) % 4)
-    return base64.urlsafe_b64decode(input_str + padding)
+@lru_cache(maxsize=1)
+def get_cognito_public_keys():
+    """Fetch and cache Cognito public keys (JWKS)."""
+    AWS_REGION = os.environ["AWS_REGION"]
+    user_pool_id = os.environ.get("COGNITO_USER_POOL_ID")
+    
+    if not user_pool_id:
+        raise PermissionError("COGNITO_USER_POOL_ID environment variable not set")
+    
+    jwks_url = f"https://cognito-idp.{AWS_REGION}.amazonaws.com/{user_pool_id}/.well-known/jwks.json"
+    response = requests.get(jwks_url, timeout=5)
+    response.raise_for_status()
+    return response.json()
 
 
+def get_signing_key(token: str):
+    """Get the signing key for a given token from Cognito JWKS."""
+    jwks = get_cognito_public_keys()
+    unverified_header = jwt.get_unverified_header(token)
+    
+    for key in jwks.get("keys", []):
+        if key["kid"] == unverified_header["kid"]:
+            return jwt.algorithms.RSAAlgorithm.from_jwk(json.dumps(key))
+    
+    raise PermissionError("Unable to find matching signing key")
+
+
+def decode_jwt(token: str) -> dict:
+    """Decode and verify JWT token against Cognito public keys."""
+    try:
+        signing_key = get_signing_key(token)
+        return jwt.decode(
+            token,
+            signing_key,
+            algorithms=["RS256"],
+            options={"verify_aud": False}  # Cognito doesn't always set aud
+        )
+    except jwt.ExpiredSignatureError:
+        raise PermissionError("Token has expired")
+    except jwt.InvalidTokenError as e:
+        raise PermissionError(f"Invalid token: {e}")
+
+
+# Keep for backward compatibility but mark as unsafe
 def decode_jwt_no_verify(token: str) -> dict:
+    """
+    DEPRECATED: Use decode_jwt() instead.
+    WARNING: This does not verify the token signature.
+    Only use if token was already verified by API Gateway/ALB.
+    """
     parts = token.split(".")
     if len(parts) < 2:
         raise PermissionError("Invalid token format")
 
     payload = parts[1]
-    decoded = base64url_decode(payload)
+    padding = "=" * (-len(payload) % 4)
+    decoded = base64.urlsafe_b64decode(payload + padding)
     return json.loads(decoded)
 
 
@@ -29,7 +78,8 @@ def get_permissions_from_event(event: dict) -> list:
     if not token:
         raise PermissionError("Missing X-Permissions-Token header")
 
-    payload = decode_jwt_no_verify(token)
+    # Use verified decoding
+    payload = decode_jwt(token)
 
     permissions = payload.get("permissions")
     if not isinstance(permissions, list):


### PR DESCRIPTION
This pull request introduces a secure and robust JWT authentication flow for Cognito in the `shared/utils/auth.py` module. The main improvements include fetching and caching Cognito public keys, verifying JWT tokens using these keys, and updating the permission extraction logic to use signature-verified tokens. Deprecated and unsafe decoding methods are clearly marked to avoid misuse.

**Authentication and JWT verification improvements:**

* Added `get_cognito_public_keys()` to fetch and cache Cognito JWKS, ensuring public keys are available for token verification.
* Implemented `get_signing_key()` to select the correct public key for a given JWT, enabling secure verification.
* Added `decode_jwt()` to verify and decode JWT tokens using Cognito public keys, handling token expiration and invalid signatures.
* Updated `get_permissions_from_event()` to use the secure `decode_jwt()` method instead of the unsafe decoding, enforcing signature verification for permissions extraction.

**Deprecation and backward compatibility:**

* Marked `decode_jwt_no_verify()` as deprecated and unsafe, clarifying its limited use cases and discouraging its usage.

**please help check if the env value (AWS_REGION & COGNITO_USER_POOL_ID) is exists on server config @coy102 @tsenagumelar 